### PR TITLE
Fix broken error handling when opening Guide Manager.

### DIFF
--- a/release/scripts/mgear/shifter/guide_manager_component.py
+++ b/release/scripts/mgear/shifter/guide_manager_component.py
@@ -117,7 +117,6 @@ class GuideManagerComponent(MayaQWidgetDockableMixin, QtWidgets.QDialog):
                     pm.displayWarning(
                         "{} can't be load. Error at import".format(comp_name)
                     )
-                    pm.displayError(e)
                     pm.displayError(traceback.format_exc())
 
         pm.progressWindow(e=True, endProgress=True)


### PR DESCRIPTION
## Description of Changes

Please clearly state what you have changed and why you made these changes.

Errors in custom components when opening Guide Manager only show `TypeError` instead of the relevant error because the exception instance is passed to `pm.displayError`, which only accepts `str` arg.
Remove an extraneous call with the incorrect arg.

## Testing Done

Please describe the tests that you ran to verify your changes.

Tested with:
* Maya 2026
* mGear 5.1.0

Intentional error in custom component properly shows in output instead of unrelated TypeError.

## Related Issue(s)

Please link the related issues.

N/A

