### PR TITLE
Add return value to `shifter.guide.Rig().drawNewComponent()`.

### DIFF
--- a/release/scripts/mgear/shifter/guide.py
+++ b/release/scripts/mgear/shifter/guide.py
@@ -804,6 +804,9 @@ class Rig(Main):
             parent (dagNode): Parent of this new component guide.
             compType (str): Type of component to add.
 
+        Returns:
+            True if the component guide instance was created, False or None if not.
+
         """
         comp_guide = self.getComponentGuide(comp_type)
 
@@ -841,7 +844,7 @@ class Rig(Main):
 
                 parent_root = parent_root.getParent()
 
-        comp_guide.drawFromUI(parent, showUI)
+        return comp_guide.drawFromUI(parent, showUI)
 
     def drawUpdate(self, oldRoot, parent=None):
 


### PR DESCRIPTION
## Description of Changes

### What changed?
I've updated `shifter.guide.Rig().drawNewComponent()` to return a True/False value based on whether a component guide was created. This reuses the return value of wrapped `ComponentGuide.drawFromUI()` method.

### Why?
I want to be able to determine, in code, whether a component was created. 

## Testing Done

Maya 2026
mGear 5.1.0
EPIC Mannequin Template, Y-up

Successfully create guide and build/rebuild rig.

## Related Issue(s)

N/A



