### PR TITLE
Expand vars for custom steps

### DIFF
--- a/release/scripts/mgear/shifter/guide.py
+++ b/release/scripts/mgear/shifter/guide.py
@@ -1477,7 +1477,7 @@ class HelperSlots(object):
                     )
                 else:
                     runPath = stepPath
-
+                runPath = os.path.expandvars(runPath)
                 customStep = imp.load_source(fileName, runPath)
                 if hasattr(customStep, "CustomShifterStep"):
                     argspec = inspect.getfullargspec(


### PR DESCRIPTION
## Description of Changes

I want to be able to use environment variables in file paths for pre and post build scripts

## Testing Done

I used environment variables in some pre and post script paths and it went fine, was not working before that change.





