### PR TITLE
Fix "Show Settings After Create" checkbox not working in PySide6

### DIFF
--- a/release/scripts/mgear/shifter/guide_manager_component.py
+++ b/release/scripts/mgear/shifter/guide_manager_component.py
@@ -268,6 +268,9 @@ class GuideManagerComponent(MayaQWidgetDockableMixin, QtWidgets.QDialog):
 
     def draw_component(self, parent=None):
         showUI = self.gmcUIInst.showUI_checkBox.checkState()
+        if isinstance(showUI, QtCore.Qt.CheckState):
+            showUI = showUI.value
+        showUI = bool(showUI)
         for x in self.gmcUIInst.component_listView.selectedIndexes():
             guide_manager.draw_comp(x.data(), parent, showUI)
 


### PR DESCRIPTION
## Description of Changes

"Show settings after component creation" checkbox doesn't work in PySide6.

Add check for PySide6, where `QCheckBox.checkState()` returns enum member, which always evaluates true. 

## Testing Done

Maya 2026
mGear 5.1.0

Can successfully create components in Guide Manager without settings pop-up when checkbox is off.

## Related Issue(s)

N/A



