### PR TITLE
Guide traversal support in core dag and component guide using the new…

### DIFF
--- a/release/scripts/mgear/core/dag.py
+++ b/release/scripts/mgear/core/dag.py
@@ -255,3 +255,39 @@ def findComponentChildren3(node, name, sideIndex):
             children.append(item)
 
     return [pm.PyNode(x) for x in children]
+
+
+def findComponentChildren4(node: pm.PyNode, name: str, sideIndex: str) -> list[pm.PyNode]:
+    """
+    Return all transform DAG nodes that belong to a given component.
+
+    :param pm.PyNode node: The root node whose hierarchy to search.
+    :param str name: Component name, for example "root" or "ik_hand_root".
+    :param str sideIndex: Side or index string, for example "C0".
+    :return: Matching transform nodes belonging to the component.
+    :rtype: list[pm.PyNode]
+    """
+    name_tokens = name.split("_")
+    prefix_len = len(name_tokens) + 1
+    children = set()
+
+    # -- All descendant transforms plus the node itself
+    paths = pm.listRelatives(node.name(),
+                             allDescendents=True,
+                             fullPath=True,
+                             type="transform") or []
+
+    for path in paths:
+        check_name = path.split("|")[-1]
+        parts = check_name.split("_")
+
+        # -- Check if transform belongs to the component
+        is_component = (len(parts) >= prefix_len
+                        and parts[:prefix_len - 1] == name_tokens
+                        and parts[prefix_len - 1] == sideIndex)
+
+        if is_component:
+            children.add(path)
+
+    return [pm.PyNode(x) for x in children]
+

--- a/release/scripts/mgear/shifter/component/guide.py
+++ b/release/scripts/mgear/shifter/component/guide.py
@@ -590,7 +590,7 @@ class ComponentGuide(guide.Main):
         # objList = dag.findComponentChildren(self.parent,
         #                                     oldName, oldSideIndex)
         # NOTE: Experimenta  using findComponentChildren3
-        objList = dag.findComponentChildren3(self.parent, oldName, oldSideIndex)
+        objList = dag.findComponentChildren4(self.parent, oldName, oldSideIndex)
         newSideIndex = newSide + str(self.values["comp_index"])
         objList.append(self.parent)
         for obj in objList:


### PR DESCRIPTION
**Description of Changes**

Introduced a new function, findComponentChildren4, to replace the previous child-collection logic.
The older implementation was matching nodes from unrelated components due to partial string matching, which caused naming collisions and incorrect traversal results.

The new version uses stricter token-based matching and reliably limits the search to nodes that belong to the intended component only.

This prevents accidental inclusion of similarly named nodes such as:

- root_C0_root (actual component)
- ik_hand_root_C0_root (different component but previously matched)

**Testing Done**

Verified the function on isolated components.

- Tested on complex guides exhibiting the previous failure cases, including components with overlapping name tokens.
- Confirmed that nodes such as root_C0_root no longer incorrectly match nodes from components like ik_hand_root_C0_root.
- Validated that the change eliminates the runaway auto-renaming loop that previously generated dozens of unnecessary index variations.

All tests confirm correct component isolation and stable traversal without unintended matches.


