### PR TITLE
Add single-undo decorators to guide creation and rename methods.

### DIFF
--- a/release/scripts/mgear/shifter/component/guide.py
+++ b/release/scripts/mgear/shifter/component/guide.py
@@ -17,7 +17,7 @@ from mgear.core import string
 from mgear.core import node
 from mgear.pymaya import versions
 
-from mgear.core import dag, vector, transform, applyop, attribute, icon, pyqt
+from mgear.core import dag, vector, transform, applyop, attribute, icon, pyqt, utils
 
 from mgear.shifter import guide, guide_manager
 from . import chain_guide_initializer
@@ -557,6 +557,7 @@ class ComponentGuide(guide.Main):
 
         return True
 
+    @utils.one_undo
     def rename(self, root, newName, newSide, newIndex):
         """Rename the component.
 

--- a/release/scripts/mgear/shifter/guide.py
+++ b/release/scripts/mgear/shifter/guide.py
@@ -797,6 +797,7 @@ class Rig(Main):
         )
         self.controllers_org.attr("visibility").set(0)
 
+    @utils.one_undo
     def drawNewComponent(self, parent, comp_type, showUI=True):
         """Add a new component to the guide.
 


### PR DESCRIPTION
## Description of Changes

Add single-undo decorators to guide creation and rename methods.

## Testing Done

Maya 2026
mGear 5.1.2
Successful build/rebuild of Mannequin Y-up template sample.
Component creation and rename is undone with a single undo.

## Related Issue(s)

N/A



