### PR TITLE
Initial submit for the guide explorer feature.

### DIFF
--- a/release/scripts/mgear/shifter/guide.py
+++ b/release/scripts/mgear/shifter/guide.py
@@ -998,20 +998,20 @@ class Rig(Main):
         if pm.attributeQuery("ismodel", node=sel, ex=True):
             self.model = sel
         else:
-            pm.displayWarning("select the top guide node")
+            pm.displayWarning("Select the top guide node.")
             return
 
         name = self.model.name()
         self.setFromHierarchy(self.model, True)
         if self.valid and not force:
-            pm.displayInfo("The Guide is updated")
+            pm.displayInfo("The guide is up to date.")
             return
 
         pm.rename(self.model, name + "_old")
         deleteLater = self.model
         self.drawUpdate(deleteLater)
         pm.rename(self.model, name)
-        pm.displayInfo("The guide %s have been updated" % name)
+        pm.displayInfo(f"Guide successfully updated: {name}")
         pm.delete(deleteLater)
 
     def duplicate(self, root, symmetrize=False):

--- a/release/scripts/mgear/shifter/guide_explorer/guide_explorer_widget.py
+++ b/release/scripts/mgear/shifter/guide_explorer/guide_explorer_widget.py
@@ -1,0 +1,600 @@
+from mgear.vendor.Qt import QtCore, QtWidgets
+import logging
+
+from typing import Optional
+
+from mgear.shifter.guide_explorer import guide_tree_widget
+from mgear.shifter.guide_explorer.models import ShifterComponent
+from mgear.shifter.guide_explorer.utils import TempSelection
+from mgear.shifter import guide as shifter_guide
+from mgear.shifter import utils as shifter_utils
+
+from mgear import shifter
+
+from mgear.core import pyqt
+import mgear.pymaya as pm
+
+logger = logging.getLogger("Guide Explorer")
+
+import importlib
+importlib.reload(shifter_utils)
+
+
+class GuideExplorerWidget(QtWidgets.QWidget):
+    """
+    Widget displaying an overview of the current mGear guide.
+
+    Provides a split layout with:
+
+    - Left panel: search bar and component tree view.
+    - Right panel: displays one of the following:
+      - Guide settings when the guide root is selected.
+      - Component settings when a component is selected.
+      - A placeholder when no selection is active.
+    """
+    TREE_MIN_WIDTH = 280
+    RIGHT_MIN_WIDTH = 420
+
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        """
+        Initialize the guide explorer widget.
+
+        :param parent: Optional parent widget.
+        :return: None
+        """
+        super().__init__(parent)
+
+        self.current_widget: Optional[QtWidgets.QWidget] = None
+        self.current_key: Optional[str] = None
+        self.previous_guide_tab_index: int = 0
+        self.previous_comp_tab_index: int = 0
+        self.last_split_sizes: List[int] = [340, 700]
+
+        self.create_widgets()
+        self.create_layout()
+        self.create_connections()
+
+    def create_widgets(self) -> None:
+        """
+        Create and configure all child widgets for the guide explorer.
+
+        :return: None
+        """
+        self.filter_components_line_edit = QtWidgets.QLineEdit(self)
+        self.filter_components_line_edit.setClearButtonEnabled(True)
+        self.filter_components_line_edit.setPlaceholderText("<Search components>")
+
+        self.sync_checkbox = QtWidgets.QCheckBox("Sync Selection")
+
+        self.guide_tree_widget = guide_tree_widget.GuideTreeWidget()
+
+        self.left_widget = QtWidgets.QWidget(self)
+        self.right_widget = QtWidgets.QWidget(self)
+
+        self.right_scroll = QtWidgets.QScrollArea(self)
+        self.right_scroll.setWidgetResizable(True)
+        self.right_scroll.setFrameShape(QtWidgets.QFrame.NoFrame)
+        self.right_scroll.setWidget(self.right_widget)
+
+        self.placeholder_label = QtWidgets.QLabel("Select a component")
+        self.placeholder_label.setAlignment(QtCore.Qt.AlignCenter)
+
+    def create_layout(self) -> None:
+        """
+        Create the main layout for the guide explorer.
+
+        :return: None
+        """
+        main_layout = QtWidgets.QVBoxLayout(self)
+        main_layout.setContentsMargins(3, 3, 3, 3)
+        main_layout.setSpacing(6)
+
+        horizontal_layout = QtWidgets.QHBoxLayout()
+        horizontal_layout.addWidget(self.filter_components_line_edit)
+        horizontal_layout.addWidget(self.sync_checkbox)
+
+        # -- Components tree widget layout
+        left_layout = QtWidgets.QVBoxLayout(self.left_widget)
+        left_layout.setContentsMargins(0, 0, 0, 0)
+        left_layout.addLayout(horizontal_layout)
+        left_layout.addWidget(self.guide_tree_widget)
+
+        self.left_widget.setMinimumWidth(self.TREE_MIN_WIDTH)
+        self.left_widget.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
+                                       QtWidgets.QSizePolicy.Expanding)
+
+        self.right_layout = QtWidgets.QVBoxLayout(self.right_widget)
+        self.right_layout.setContentsMargins(0, 0, 0, 0)
+        self.right_layout.addWidget(self.placeholder_label)
+
+        self.splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        self.splitter.addWidget(self.left_widget)
+        self.splitter.addWidget(self.right_scroll)
+        self.splitter.setCollapsible(0, False)
+        self.splitter.setCollapsible(1, False)
+        self.splitter.setStretchFactor(0, 0)
+        self.splitter.setStretchFactor(1, 1)
+        self.splitter.setSizes(self.last_split_sizes)
+
+        main_layout.addWidget(self.splitter)
+
+    def create_connections(self) -> None:
+        """
+        Connect widget signals to their corresponding slots.
+
+        :return: None
+        """
+        self.filter_components_line_edit.textChanged.connect(self.apply_component_filter)
+
+        self.guide_tree_widget.itemSelectionChanged.connect(self.on_selection_changed_clicked)
+        self.guide_tree_widget.doubleClicked.connect(self.on_item_double_clicked)
+        self.guide_tree_widget.labelsUpdated.connect(self.refresh_widget_titles)
+        self.guide_tree_widget.selectionPayloadRenamed.connect(self.refresh_selected_widget)
+
+        self.sync_checkbox.toggled.connect(self.on_sync_checkbox_toggled)
+
+    def on_selection_changed_clicked(self) -> None:
+        """
+        Update the settings panel based on the current tree selection.
+
+        Displays either the guide settings, component settings or
+        a placeholder if nothing is selected.
+
+        :return: None
+        """
+        items = self.guide_tree_widget.selectedItems()
+        if not items:
+            self.show_placeholder()
+            return
+
+        # -- Stored information when loading in the guide and components
+        data = items[-1].data(0, guide_tree_widget.DATA_ROLE)
+
+        # -- Shifter Component Instance
+        if isinstance(data, ShifterComponent) and data.root_name:
+            self.open_component_widget(data)
+
+            # -- Safe select via the node uuid
+            if self.sync_checkbox.isChecked():
+                shifter_utils.select_by_uuid(uuid=data.uuid)
+
+            return
+
+        # -- Guide object
+        if self._is_pymaya_node(data) or isinstance(data, str):
+            self.open_guide_widget(data)
+
+            if self.sync_checkbox.isChecked():
+                shifter_utils.select_items(items=[data])
+            return
+
+        # -- Default to showing the placeholder if nothing is selected
+        self.show_placeholder()
+
+    def on_item_double_clicked(self) -> None:
+        """
+        Select the single node corresponding to the double-clicked item.
+
+        If sync selection is enabled, this is skipped because selection is
+        already driven by single-click.
+
+        :return: None
+        """
+        # -- No need to do selection as the single click will have done it's job.
+        if self.sync_checkbox.isChecked():
+            return
+
+        items = self.guide_tree_widget.selectedItems()
+        data = items[-1].data(0, guide_tree_widget.DATA_ROLE)
+
+        # -- Component
+        if isinstance(data, ShifterComponent):
+            shifter_utils.select_by_uuid(uuid=data.uuid)
+
+        # -- Guide
+        if self._is_pymaya_node(data) or isinstance(data, str):
+            shifter_utils.select_items(items=[data])
+
+    def remember_and_restore_split(self, restore=True) -> None:
+        """
+        Save or restore the splitter sizes.
+
+        :param restore: If True, restore the last saved sizes.
+                        If False, save the current sizes.
+        :return: None
+        """
+        if restore:
+            self.splitter.setSizes(self.last_split_sizes)
+        else:
+            self.last_split_sizes = self.splitter.sizes()
+
+    def clear_right(self) -> None:
+        """
+        Remove the current panel from the right side and reset related data.
+
+        :return: None
+        """
+        if self.current_widget:
+            self.right_layout.removeWidget(self.current_widget)
+            self.current_widget.deleteLater()
+            self.current_widget = None
+            self.current_key = None
+
+    def set_right_min_width(self, width: int) -> None:
+        """
+        Set the minimum width for the right panel and its scroll area.
+
+        :param width: Desired minimum width in pixels.
+        :return: None
+        """
+        width = max(self.RIGHT_MIN_WIDTH, int(width))
+        self.right_widget.setMinimumWidth(width)
+        self.right_scroll.setMinimumWidth(width)
+
+    def clear_right_min_width(self) -> None:
+        """
+        Reset the minimum width of the right panel to zero.
+
+        :return: None
+        """
+        self.right_widget.setMinimumWidth(0)
+        self.right_scroll.setMinimumWidth(0)
+
+    def remove_placeholder(self) -> None:
+        """
+        Remove the placeholder label from the right panel if it exists.
+
+        :return: None
+        """
+        if self.placeholder_label:
+            self.placeholder_label.hide()
+
+    def ensure_placeholder(self) -> None:
+        """
+        Ensure that the placeholder label exists and is attached to the right panel.
+
+        :return: None
+        """
+        if self.placeholder_label.parent() is None:
+            self.placeholder_label.setParent(self.right_widget)
+            self.right_layout.addWidget(self.placeholder_label)
+
+        self.placeholder_label.show()
+
+    def show_placeholder(self) -> None:
+        """
+        Clear the right panel and display the placeholder label.
+
+        :return: None
+        """
+        self.clear_right()
+        self.clear_right_min_width()
+        self.ensure_placeholder()
+
+    def on_panel_close_button(self, panel: QtWidgets.QWidget) -> None:
+        """
+        Ensure that closing an embedded settings panel restores the placeholder.
+
+        :param panel: Guide or component settings widget that has a close_button.
+        """
+        # -- Most mGear settings panels expose a 'close_button' attribute.
+        close_button = getattr(panel, "close_button", None)
+        if isinstance(close_button, QtWidgets.QPushButton):
+            close_button.clicked.connect(self.show_placeholder)
+
+    def open_guide_widget(self, data=None) -> None:
+        """
+        Build and display the guide settings panel on the right side.
+
+        :param data: ShifterComponent describing the selected component.
+        :return: None
+        """
+        self.remember_and_restore_split(restore=False)
+
+        if self.current_key == "__GUIDE__" and self.current_widget:
+            self.previous_guide_tab_index = self.current_widget.tabs.currentIndex()
+
+        if data is None:
+            item = self.guide_tree_widget.topLevelItem(0)
+            data = item.data(0, guide_tree_widget.DATA_ROLE) if item else None
+
+        # -- Temporarily select the guide root only while building the panel
+        # -- If we do not select the item then the data is not loaded in.
+        with TempSelection(data):
+            panel = shifter_guide.GuideSettings(parent=self.right_widget)
+
+        panel.setWindowFlags(QtCore.Qt.Widget)
+        panel.setAttribute(QtCore.Qt.WA_DeleteOnClose, False)
+        panel.setObjectName("guide_settings_panel")
+
+        self.on_panel_close_button(panel=panel)
+
+        panel_min_width = max(panel.minimumSizeHint().width(), panel.sizeHint().width())
+        self.set_right_min_width(panel_min_width)
+
+        # -- Clean widgets and ensure the placeholder label is removed
+        self.clear_right()
+        self.remove_placeholder()
+        self.current_widget = panel
+        self.current_key = "__GUIDE__"
+        self.right_layout.addWidget(panel)
+
+        # -- Set the last known index for the guide
+        panel.tabs.setCurrentIndex(self.previous_guide_tab_index)
+
+        self.remember_and_restore_split(restore=True)
+
+    def open_component_widget(self, comp: ShifterComponent) -> None:
+        """
+        Build and display the component settings panel on the right side.
+
+        :param comp: ShifterComponent describing the selected component.
+        :return: None
+        """
+        # -- If leaving the guide, remember current tab index
+        if self.current_key == "__GUIDE__" and self.current_widget and hasattr(self.current_widget, "tabs"):
+            self.previous_guide_tab_index = self.current_widget.tabs.currentIndex()
+
+        # -- No need to rebuild if this component is already shown
+        if self.current_key == comp.full_name and self.current_widget:
+            return
+
+        if self.current_widget and self.current_key != "__GUIDE__":
+            self.previous_comp_tab_index = self.current_widget.tabs.currentIndex()
+
+        self.remember_and_restore_split(restore=False)
+
+        # -- Resolve the scene node from the UUID
+        try:
+            root_node = pm.ls(comp.uuid, uuid=True)[0]
+        except Exception:
+            logger.warning(f"Could not resolve component root from uuid '{comp.uuid}' for component '{comp.full_name}' "
+                           f"The node may have been deleted or renamed.")
+            self.show_placeholder()
+            self.remember_and_restore_split(restore=True)
+            return
+
+        # -- Keep the dataclass in sync if the node has been renamed
+        if root_node.name() != comp.root_name:
+            comp = ShifterComponent(full_name=comp.full_name,
+                                    comp_type=comp.comp_type,
+                                    root_name=root_node.name(),
+                                    side=comp.side,
+                                    index=comp.index,
+                                    uuid=comp.uuid)
+
+        # -- Import the component guide module and try to get its UI class.
+        component_instance = shifter.importComponentGuide(comp.comp_type)
+        SettingsCls = getattr(component_instance, "componentSettings", None)
+        if SettingsCls is None:
+            self.show_placeholder()
+            self.remember_and_restore_split(restore=True)
+            return
+
+        # -- Temporarily select the component root only while building the panel
+        # -- If we do not select the item then the data is not loaded in.
+        with TempSelection(comp.root_name):
+            panel = SettingsCls(parent=self.right_widget)
+
+        panel.setWindowFlags(QtCore.Qt.Widget)
+        panel.setAttribute(QtCore.Qt.WA_DeleteOnClose, False)
+        panel.setObjectName(f"{comp.full_name}_settings")
+
+        self.on_panel_close_button(panel=panel)
+
+        panel_min_width = max(panel.minimumSizeHint().width(), panel.sizeHint().width())
+        self.set_right_min_width(panel_min_width)
+
+        self.clear_right()
+        self.remove_placeholder()
+        self.current_widget = panel
+        self.current_key = comp.full_name
+        self.right_layout.addWidget(panel)
+
+        # -- Want to get the current tab count as the stored index could be
+        # -- Higher than the new component tab count.
+        tab_count = panel.tabs.count()
+        if self.previous_comp_tab_index >= tab_count:
+            self.previous_comp_tab_index = max(0, tab_count - 1)
+
+        panel.tabs.setCurrentIndex(self.previous_comp_tab_index)
+
+        self.remember_and_restore_split(restore=True)
+
+    def apply_component_filter(self, text: str) -> None:
+        """
+        Filter tree items by name and type using the given search text.
+
+        :param text: Space-separated terms; all must match for an item to stay visible.
+        :return: None
+        """
+        # -- This should always be the guide
+        root_item = self.guide_tree_widget.topLevelItem(0)
+
+        if not root_item:
+            return
+
+        search_terms = [t.lower() for t in text.strip().split() if t]
+        root_item.setHidden(False)
+        root_item.setExpanded(True)
+        # -- Search all child items in the tree widget
+        for i in range(root_item.childCount()):
+            item = root_item.child(i)
+            comb = f"{item.text(0)} {item.text(1)}".lower()
+            item.setHidden(not all(t in comb for t in search_terms))
+
+    def component_exists(self, full_name: str) -> bool:
+        """
+        Check whether a component with the given full name exists in the tree.
+
+        :param full_name: Full name of the component to look for.
+        :return: True if the component is found, otherwise False.
+        """
+        # -- This is the mGear guide
+        root = self.guide_tree_widget.topLevelItem(0)
+        if not root:
+            return False
+
+        # -- Iterate over all the child items and ensure that the component full name exists
+        for i in range(root.childCount()):
+            data = root.child(i).data(0, guide_tree_widget.DATA_ROLE)
+            if isinstance(data, ShifterComponent) and data.full_name == full_name:
+                return True
+
+        return False
+
+    def refresh_selected_widget(self) -> None:
+        """
+        Reload the panel for the currently selected item.
+
+        Reopens the appropriate settings panel when the selected guide or
+        component has changed identity or attributes, ensuring the displayed
+        content stays in sync with the scene.
+
+        :return: None
+        """
+        items = self.guide_tree_widget.selectedItems()
+        if not items:
+            return
+
+        data = items[-1].data(0, guide_tree_widget.DATA_ROLE)
+        if isinstance(data, ShifterComponent):
+            self.open_component_widget(data)
+        else:
+            self.open_guide_widget(data)
+
+    def refresh_widget_titles(self) -> None:
+        """
+        Refresh the tree view and update the active widget title.
+
+        Ensures renamed guides or components display correctly in both the
+        tree and the right-hand panel by repainting the tree viewport and
+        updating the current widget's window title if needed.
+
+        :return: None
+        """
+        # -- Force tree repaint
+        self.guide_tree_widget.viewport().update()
+
+        # -- If the current widget is open for a component that got renamed,
+        # -- refresh the title or label on that widget
+        if self.current_widget and hasattr(self.current_widget, 'setWindowTitle'):
+            items = self.guide_tree_widget.selectedItems()
+            if items:
+                data = items[-1].data(0, guide_tree_widget.DATA_ROLE)
+                # -- if a component
+                if isinstance(data, ShifterComponent):
+                    self.current_widget.setWindowTitle(data.full_name)
+                # -- if a guide
+                else:
+                    self.current_widget.setWindowTitle("Guide Settings")
+
+    def on_sync_checkbox_toggled(self, state: bool) -> None:
+        """
+        Handle toggling of the 'Sync Selection' checkbox.
+
+        Updates the internal flag on the tree widget that controls whether
+        scene selection changes should update the tree selection. The actual
+        setting is persisted during teardown, not on each toggle.
+
+        :param state: True if sync selection is enabled, otherwise False.
+        :return: None
+        """
+        self.guide_tree_widget._scene_sync_enabled = state
+
+    def refresh(self) -> None:
+        """
+        Update the tree to reflect the current scene state.
+
+        Reloads the guide data from the scene and resets the view if the
+        previously selected component no longer exists.
+
+        :return: None
+        """
+        self.guide_tree_widget.get_guide_from_scene()
+        if self.current_key and not self.component_exists(self.current_key):
+            self.show_placeholder()
+
+    def _is_pymaya_node(self, obj) -> bool:
+        """
+        Check if the given object behaves like a PyMaya or PyNode instance.
+
+        :param obj: Object to test.
+        :return: True if the object has a callable ``name()`` method.
+        """
+        return hasattr(obj, "name") and callable(getattr(obj, "name", None))
+
+    def _load_settings(self) -> None:
+        """
+        Load persistent settings for the guide overview widget.
+
+        Restores sync selection state and the component filter text.
+
+        :return: None
+        """
+        settings = QtCore.QSettings("mgear", "GuideExplorer")
+
+        # -- Sync Selection checkbox
+        sync_enabled = settings.value("sync_selection", False, type=bool)
+        self.sync_checkbox.setChecked(sync_enabled)
+        self.guide_tree_widget._scene_sync_enabled = sync_enabled
+
+        # -- Component filter text
+        saved_filter = settings.value("component_filter", "", type=str)
+        self.filter_components_line_edit.setText(saved_filter)
+
+        if saved_filter:
+            # -- Setting the text will also trigger apply_component_filter
+            self.apply_component_filter(saved_filter)
+
+    def _save_settings(self) -> None:
+        """
+        Save persistent settings for the guide overview widget.
+
+        Called on teardown so we only write once per session.
+
+        :return: None
+        """
+        settings = QtCore.QSettings("mgear", "GuideExplorer")
+
+        settings.setValue("sync_selection", self.sync_checkbox.isChecked())
+        settings.setValue("component_filter", self.filter_components_line_edit.text() or "")
+
+    def showEvent(self, event) -> None:
+        """
+        Refresh the widget when it becomes visible.
+
+        :param event: Qt show event.
+        :return: None
+        """
+        super(GuideExplorerWidget, self).showEvent(event)
+        self.refresh()
+        self._load_settings()
+
+    def hideEvent(self, event) -> None:
+        """
+        Handle widget hide events.
+
+        Persists settings when the widget is hidden.
+
+        :param event: Qt hide event.
+        :return: None
+        """
+        super().hideEvent(event)
+
+        self._save_settings()
+
+    def teardown(self) -> None:
+        """
+        Clean up callbacks and cached data before closing the widget.
+
+        This removes all managed callbacks and clears the node maps to prevent
+        stale references or memory leaks. This is called when we close the UI.
+
+        :return: None
+        """
+        try:
+            self.guide_tree_widget.teardown()
+            self._save_settings()
+        except Exception:
+            pass

--- a/release/scripts/mgear/shifter/guide_explorer/guide_tree_widget.py
+++ b/release/scripts/mgear/shifter/guide_explorer/guide_tree_widget.py
@@ -1,0 +1,899 @@
+from mgear.vendor.Qt import QtCore, QtWidgets, QtGui
+
+import importlib
+import logging
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, List, Optional
+
+from maya.api import OpenMaya as om
+
+from mgear import shifter
+from mgear.core import callbackManager as cb
+
+from mgear.shifter import guide_manager
+from mgear.shifter import utils as shifter_utils
+from mgear.shifter.guide_explorer import guide_tree_widget_items
+from mgear.shifter.guide_explorer.models import ShifterComponent
+
+from mgear.compatible import compatible_comp_dagmenu
+
+importlib.reload(shifter_utils)
+importlib.reload(guide_tree_widget_items)
+
+logger = logging.getLogger("Guide Explorer - Tree Widget")
+
+DATA_ROLE = QtCore.Qt.UserRole + 1
+
+ATTRS_GUIDE = ["rig_name"]
+ATTRS_COMP  = ["comp_name", "comp_side", "comp_index"]
+
+
+class GuideTreeWidget(QtWidgets.QTreeWidget):
+    """
+    Tree widget displaying the active mGear guide and its components.
+
+    Supports building, unbuilding, duplicating, mirroring, deleting,
+    and adding components through a context menu or keyboard shortcuts.
+    Also integrates with a Component Manager dialog for creating new components.
+
+    :ivar _guide: Cached guide root or query result from the scene.
+    :ivar component_manager: Dialog used for selecting and creating components.
+    """
+    labelsUpdated = QtCore.Signal()
+    selectionPayloadRenamed = QtCore.Signal()
+
+    def __init__(self, guide=None):
+        """
+        Initialize the tree widget and connect actions and signals.
+
+        :param guide: Optional initial guide reference to populate the tree.
+        :return: None
+        """
+        super(GuideTreeWidget, self).__init__()
+
+        self._attr_cb_manager = cb.CallbackManager()
+        self._selection_cb_manager = cb.CallbackManager()
+        self._node_to_item = {}
+        self._uuid_to_item = {}
+        self._guide = guide
+        self.component_manager = None
+
+        self._block_scene_selection_sync = False
+        self._scene_sync_enabled = False
+        self._scene_callbacks_active = False
+
+        self._node_added_cb_id = None
+        self._node_removed_cb_id = None
+
+        # -- This part is critical for the callbacks slowing down
+        # -- when building and importing
+        self._pending_scene_refresh = False
+        self._node_added_timer = QtCore.QTimer(self)
+        self._node_added_timer.setSingleShot(True)
+        self._node_added_timer.timeout.connect(self._process_pending_scene_refresh)
+
+        self.add_actions()
+        self.create_widgets()
+        self.create_connections()
+
+    def add_actions(self) -> None:
+        """
+        Create QAction instances and register them on the widget.
+
+        Actions are also added to the widget so that their shortcuts remain
+        active even when the context menu is closed.
+
+        :return: None
+        """
+        self.refresh_action = QtWidgets.QAction("Refresh", self)
+        self.refresh_action.setShortcut(QtGui.QKeySequence("R"))
+        self.refresh_action.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
+
+        self.mirror_component_action = QtWidgets.QAction("Mirror", self)
+
+        self.build_action = QtWidgets.QAction("Build", self)
+        self.build_action.setShortcut(QtGui.QKeySequence("Ctrl+B"))
+        self.build_action.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
+
+        self.unbuild_action = QtWidgets.QAction("Unbuild", self)
+        self.unbuild_action.setShortcut(QtGui.QKeySequence("Ctrl+U"))
+        self.unbuild_action.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
+
+        self.delete_action = QtWidgets.QAction("Delete", self)
+        self.delete_action.setShortcut(QtGui.QKeySequence("Del"))
+        self.delete_action.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
+
+        self.guide_visibility_action = QtWidgets.QAction("Guide Visibility", self)
+        self.guide_visibility_action.setShortcut(QtGui.QKeySequence("H"))
+        self.guide_visibility_action.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
+
+        self.ctrl_visibility_action = QtWidgets.QAction("Control Visibility", self)
+        self.ctrl_visibility_action.setShortcut(QtGui.QKeySequence("C"))
+        self.ctrl_visibility_action.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
+
+        self.joint_visibility_action = QtWidgets.QAction("Joint Visibility", self)
+        self.joint_visibility_action.setShortcut(QtGui.QKeySequence("J"))
+        self.joint_visibility_action.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
+
+        self.select_component_action = QtWidgets.QAction("Select Component", self)
+        self.select_component_action.setShortcut(QtGui.QKeySequence("F"))
+        self.select_component_action.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
+
+        self.update_component_type_action = QtWidgets.QAction("Update Component Type", self)
+        self.update_component_type_action.setShortcut(QtGui.QKeySequence("Ctrl+U"))
+        self.update_component_type_action.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
+
+        # -- Register actions on the dialog so their shortcuts stay active.
+        # -- Without this, actions only exist in the context menu and
+        # -- their shortcuts will not trigger unless the menu is open.
+        self.addAction(self.refresh_action)
+        self.addAction(self.build_action)
+        self.addAction(self.unbuild_action)
+        self.addAction(self.delete_action)
+        self.addAction(self.guide_visibility_action)
+        self.addAction(self.ctrl_visibility_action)
+        self.addAction(self.joint_visibility_action)
+        self.addAction(self.select_component_action)
+        self.addAction(self.update_component_type_action)
+
+    def create_widgets(self) -> None:
+        """
+        Create and configure the tree columns, header, and context menu policy.
+
+        The tree uses two columns: component name and component type.
+        The header is hidden for a cleaner look but retains stretch behavior.
+
+        :return: None
+        """
+        self.setColumnCount(2)
+        self.setIndentation(10)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+
+        header = self.header()
+        header.setStretchLastSection(False)
+        header.setMinimumSectionSize(60)
+
+        # -- Make columns follow the widget width:
+        # -- Component name stretches
+        header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        # -- Type hugs content
+        header.setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeToContents)
+
+        # -- Hide the header after setting modes
+        self.setHeaderHidden(True)
+        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.viewport().setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+
+    def create_connections(self) -> None:
+        """
+        Connect UI signals to their handlers and wire actions to slots.
+
+        Includes double-click selection, context menu handling, and all
+        action triggers such as build, unbuild, mirror, delete and selection.
+
+        :return: None
+        """
+        self.customContextMenuRequested.connect(self.show_context_menu)
+
+        self.build_action.triggered.connect(self.on_build_action_clicked)
+        self.unbuild_action.triggered.connect(self.on_unbuild_action_clicked)
+        self.refresh_action.triggered.connect(self.on_refresh_action_clicked)
+        self.mirror_component_action.triggered.connect(self.on_mirror_action_clicked)
+        self.delete_action.triggered.connect(self.on_delete_action_clicked)
+
+        self.guide_visibility_action.triggered.connect(self.on_guide_visibility_action_clicked)
+        self.ctrl_visibility_action.triggered.connect(self.on_control_visibility_action_clicked)
+        self.joint_visibility_action.triggered.connect(self.on_joint_visibility_action_clicked)
+
+        self.select_component_action.triggered.connect(self.on_select_component_action_clicked)
+
+        self.update_component_type_action.triggered.connect(self.on_update_component_type_action_clicked)
+
+    def on_build_action_clicked(self) -> None:
+        """
+        Build the rig from the current selection context.
+
+        If the root item named "guide" is selected, the entire guide is built.
+        If component items are selected, their corresponding roots are selected
+        and provided to mGear Shifter for ``buildFromSelection``.
+
+        :return: None
+        """
+        selection: List[str] = []
+
+        # -- Get the UI selection
+        items = self.selectedItems()
+        for item in items:
+            comp_data = item.data(0, DATA_ROLE)
+
+            if hasattr(comp_data, "root_name"):
+                node = comp_data.root_name
+            else:
+                node = comp_data
+
+            node_name = node.name() if hasattr(node, "name") else str(node)
+            selection.append(node_name)
+
+        # -- Select all our items
+        shifter_utils.select_items(selection)
+
+        # -- Do the rig build
+        rig = shifter.Rig()
+        rig.buildFromSelection()
+
+    def on_unbuild_action_clicked(self) -> None:
+        """
+        Unbuild the current rig, if present.
+
+        The function finds any node with the attribute ``*.is_rig`` and deletes
+        the owning rig transform. Logs an error if no rig is found.
+
+        :return: None
+        """
+        # -- Get the rig in the scene
+        rig = shifter_utils.get_rig()
+
+        if not rig:
+            logger.error("No valid rig has been found in the scene to unbuild.")
+            return
+
+        # -- Delete the rig
+        rig_name = rig[0].node().name()
+        shifter_utils.delete_nodes([rig_name])
+
+    def on_refresh_action_clicked(self) -> None:
+        """
+        Refresh the tree from the current scene.
+
+        :return: None
+        """
+        self.get_guide_from_scene()
+
+    def on_mirror_action_clicked(self) -> None:
+        """
+        Mirror the selected component guide.
+
+        Only the last selected item is considered. The guide root is resolved
+        and duplicated with mirroring enabled. The tree is refreshed afterward
+        via callbacks.
+
+        :return: None
+        """
+        items = self.selectedItems()
+
+        if not items:
+            return
+
+        # -- Only consider the last selected item for now
+        item = items[-1]
+        comp_data = item.data(0, DATA_ROLE)
+
+        if not isinstance(comp_data, ShifterComponent):
+            logger.warning("Mirror is only supported for component items.")
+            return
+
+        # -- Resolve the component root as a PyNode
+        try:
+            root_node = shifter_utils.node_from_uuid(uuid=comp_data.uuid)
+        except Exception:
+            try:
+                root_node = shifter_utils.node_from_name(name=comp_data.root_name)
+            except Exception:
+                logger.warning(f"Could not resolve component root for mirroring: {comp_data.full_name}")
+                return
+
+        # -- Mirror the guide
+        guide = shifter.guide.Rig()
+        guide.duplicate(root_node, True)
+
+    def on_delete_action_clicked(self) -> None:
+        """
+        Delete selected guide or component roots from the scene.
+
+        The function resolves node names from the selection, converts component
+        items to their root nodes, and passes the list to a delete helper.
+        The tree is refreshed afterward.
+
+        :return: None
+        """
+        selection: List[str] = []
+
+        # -- Get the UI selection
+        items = self.selectedItems()
+        if not items:
+            logger.warning("No item in the UI has been selected for deletion.")
+            return
+
+        for item in items:
+            comp_data = item.data(0, DATA_ROLE)
+
+            # -- Component roots
+            if hasattr(comp_data, "root_name"):
+                node = comp_data.root_name
+            else:
+                # -- Root guide node
+                node = comp_data
+
+            selection.append(node)
+
+        # -- Do the deletion of the node
+        shifter_utils.delete_nodes(selection)
+
+        self.get_guide_from_scene()
+
+    def on_guide_visibility_action_clicked(self) -> None:
+        """
+        Toggle the visibility of the selected guide or component roots.
+
+        For each selected tree item, resolves the stored DATA_ROLE data:
+        - If it is a ShifterComponent, uses its root node.
+        - Otherwise treats the data as a node-like object.
+
+        :return: None
+        """
+        items = self.selectedItems()
+        # -- Fail/exit early
+        if not items:
+            return
+
+        for item in items:
+            comp_data = item.data(0, DATA_ROLE)
+
+            if isinstance(comp_data, ShifterComponent):
+                node = shifter_utils.node_from_uuid(uuid=comp_data.uuid)
+            else:
+                node = shifter_utils.node_from_name(name=comp_data)
+
+            visibility = node.visibility.get()
+            node.visibility.set(not visibility)
+
+    def on_control_visibility_action_clicked(self) -> None:
+        """
+        Toggle the rig control visibility.
+
+        Resolves the active rig via 'shifter_utils.get_rig()', then flips the
+        'ctl_vis' attribute on the rig root if present.
+
+        :return: None
+        """
+        rig_list = shifter_utils.get_rig()
+        rig = rig_list[0].node() if rig_list and hasattr(rig_list[0], "node") else None
+
+        if not rig:
+            return
+
+        ctrl_visibility = rig.ctl_vis.get()
+        rig.ctl_vis.set(not ctrl_visibility)
+
+    def on_joint_visibility_action_clicked(self) -> None:
+        """
+        Toggle the rig joint visibility.
+
+        Resolves the active rig via 'shifter_utils.get_rig()', then flips the
+        'jnt_vis' attribute on the rig root if present.
+
+        :return: None
+        """
+        rig_list = shifter_utils.get_rig()
+        rig = rig_list[0].node() if rig_list and hasattr(rig_list[0], "node") else None
+
+        if not rig:
+            return
+
+        jnt_visibility = rig.jnt_vis.get()
+        rig.jnt_vis.set(not jnt_visibility)
+
+    def on_select_component_action_clicked(self) -> None:
+        """
+        Select the scene nodes that correspond to the selected tree items.
+
+        Builds a list of node names by reading DATA_ROLE:
+        - If a ShifterComponent is stored, resolves it via UUID.
+        - Otherwise treats the payload as a node-like object.
+
+        :return: None
+        """
+        items = self.selectedItems()
+        selection_list: List[str] = []
+
+        for item in items:
+            comp_data = item.data(0, DATA_ROLE)
+
+            if hasattr(comp_data, "root_name"):
+                node = shifter_utils.node_from_uuid(uuid=comp_data.uuid)
+            else:
+                node = comp_data
+
+            selection_list.append(node)
+
+        shifter_utils.select_items(selection_list, replace=True)
+
+    def get_guide_from_scene(self) -> None:
+        """
+        Query the scene for the active mGear guide and populate the tree.
+
+        Clears the tree, resolves the guide, rig name and component metadata,
+        then creates a root item followed by child items for each component.
+        The root item is selected by default.
+
+        :return: None
+        """
+        self._attr_cb_manager.removeAllManagedCB()
+        self.clear()
+        self._node_to_item.clear()
+        self._uuid_to_item.clear()
+
+        self._guide = shifter_utils.get_guide()
+        if not self._guide:
+            logger.warning("No Guide has been found in the scene.")
+            return
+
+        guide_name = self._guide[0].node()
+        rig_name = shifter_utils.get_rig_name(guide_name)
+        components = shifter_utils.get_components(guide_name)
+
+        root_item = guide_tree_widget_items.GuideTreeWidgetItem(parent=self,
+                                                                rig_name=rig_name)
+
+        root_item.setText(0, f"guide ({rig_name})")
+        root_item.setData(0, QtCore.Qt.UserRole, "guide")
+        root_item.setData(0, DATA_ROLE, guide_name)
+        self._node_to_item[str(guide_name)] = root_item
+
+        self._create_attr_callbacks(str(guide_name), ATTRS_GUIDE)
+
+        for comp in components:
+
+            root_node = comp.node().name()
+            comp_type = comp.comp_type.get()
+            comp_name = comp.comp_name.get()
+            comp_side = comp.comp_side.get()
+            comp_index = comp.comp_index.get()
+            root_uuid = shifter_utils.uuid_from_node(node=root_node)
+
+            full_name = f"{comp_name}_{comp_side}{comp_index}"
+
+            comp_item = guide_tree_widget_items.ComponentTreeWidgetItem(root_item,
+                                                                        full_name,
+                                                                        comp_type)
+            comp_item.setData(0, QtCore.Qt.UserRole, root_node)
+            comp_item.setData(0, DATA_ROLE, ShifterComponent(full_name=full_name,
+                                                             comp_type=comp_type,
+                                                             root_name=root_node,
+                                                             side=comp_side,
+                                                             index=comp_index,
+                                                             uuid=root_uuid))
+
+            self._node_to_item[root_node] = comp_item
+            self._uuid_to_item[root_uuid] = comp_item
+            # -- watch naming attrs on this component root
+            self._create_attr_callbacks(root_node, ATTRS_COMP)
+
+        # -- Select root so settings show on first open
+        self.setCurrentItem(root_item)
+
+    def _create_attr_callbacks(self, node_name: str, short_attrs: list[str]) -> None:
+        """
+        Register attribute change callbacks for the given node and attributes.
+
+        :param node_name: Name of the node to watch.
+        :param short_attrs: List of attribute names to track.
+        :return: None
+        """
+        # -- Create a unique name so this manager can cleanly remove them later
+        callback_namespace = f"GuideOverview.{node_name}"
+        for attr in short_attrs:
+            fn = partial(self._on_attr_changed, node_name, attr)
+            self._attr_cb_manager.attributeChangedCB(f"{callback_namespace}.{attr}",
+                                                     fn,
+                                                     node_name,
+                                                     [attr])
+
+    def _register_node_added_callback(self) -> None:
+        """
+        Register DG node-added and node-removed callbacks.
+
+        Used so the tree can refresh when new guide or component nodes
+        are created or deleted.
+
+        :return: None
+        """
+        if self._node_added_cb_id is None:
+            self._node_added_cb_id = om.MDGMessage.addNodeAddedCallback(self._on_node_added,
+                                                                        "transform")
+
+        if self._node_removed_cb_id is None:
+            self._node_removed_cb_id = om.MDGMessage.addNodeRemovedCallback(self._on_node_removed,
+                                                                            "transform")
+
+    def _on_attr_changed(self, node_name: str, attr: str) -> None:
+        """
+        Handle guide or component attribute changes and refresh the tree item.
+
+        :param node_name: Name of the node whose attribute changed.
+        :param attr: Short attribute name that triggered the callback.
+        :return: None
+        """
+        item = self._node_to_item.get(node_name)
+        if not item:
+            return
+
+        data = item.data(0, DATA_ROLE)
+
+        if isinstance(data, ShifterComponent):
+
+            node = shifter_utils.node_from_uuid(uuid=data.uuid)
+
+            comp_name = node.attr("comp_name").get()
+            comp_side = node.attr("comp_side").get()
+            comp_index = node.attr("comp_index").get()
+            comp_type = node.attr("comp_type").get()
+
+            new_full_name = f"{comp_name}_{comp_side}{comp_index}"
+            new_node_name = node.name()
+
+            self.blockSignals(True)
+
+            item.setText(0, new_full_name)
+            item.setData(0, DATA_ROLE, ShifterComponent(full_name=new_full_name,
+                                                        comp_type=comp_type,
+                                                        root_name=new_node_name,
+                                                        side=comp_side,
+                                                        index=comp_index,
+                                                        uuid=data.uuid))
+
+            # -- Update the node name mapping if the transform was renamed
+            if new_node_name != node_name:
+                self._node_to_item[new_node_name] = item
+
+            self.blockSignals(False)
+
+            self.labelsUpdated.emit()
+            if self.currentItem() is item:
+                self.selectionPayloadRenamed.emit()
+
+        # -- Either guide or component
+        else:
+
+            node = shifter_utils.node_from_name(name=data)
+
+            rig_name = node.attr("rig_name").get()
+
+            self.blockSignals(True)
+            item.setText(0, f"guide ({rig_name})")
+            self.blockSignals(False)
+
+            self.labelsUpdated.emit()
+            if self.currentItem() is item:
+                self.selectionPayloadRenamed.emit()
+
+    def _on_scene_selection_changed(self, *args: Any) -> None:
+        """
+        Sync the tree selection from the current Maya selection.
+
+        Called whenever the Maya selection changes.
+
+        :return: None
+        """
+        if not self._scene_sync_enabled or self._block_scene_selection_sync:
+            return
+
+        selection = shifter_utils.get_selection()
+        if not selection:
+            return
+
+        # -- Take the last selected object
+        last_item = selection[-1]
+
+        # -- Try to find the component root for this object
+        comp_root = shifter_utils.find_component_root(last_item)
+        if not comp_root:
+            # Might be the guide root itself
+            try:
+                node_name = last_item.name()
+            except Exception:
+                node_name = str(last_item)
+
+            item = self._node_to_item.get(node_name)
+            if not item:
+                return
+        else:
+            # -- Use uuid mapping if possible, more robust and less prone to name clashes.
+            root_node_name = comp_root.node().name()
+            try:
+                root_uuid = shifter_utils.uuid_from_node(node=root_node_name)
+                item = self._uuid_to_item.get(root_uuid)
+            except Exception:
+                item = self._node_to_item.get(root_node_name)
+
+            if not item:
+                return
+
+        # -- Update tree selection without causing extra noise
+        self._block_scene_selection_sync = True
+        try:
+            self.clearSelection()
+            self.setCurrentItem(item)
+            self.scrollToItem(item)
+            parent = item.parent()
+            if parent:
+                self.expandItem(parent)
+        finally:
+            self._block_scene_selection_sync = False
+
+    def _on_node_added(self, mobj: om.MObject, clientData: Any = None) -> None:
+        """
+        DG callback when a transform node is created.
+
+        This does not inspect custom attributes because the callback fires
+        before mGear has finished adding them. Instead, it schedules a
+        debounced tree refresh if the widget is visible and a guide is
+        currently loaded.
+
+        :param mobj: Maya object that was added.
+        :param clientData: Arbitrary client data passed by Maya.
+        :return: None
+        """
+        # -- Only care while the widget is actually visible
+        if not self.isVisible():
+            return
+
+        self._pending_scene_refresh = True
+
+        # -- Restart the debounce timer. If more nodes are added before the timeout,
+        # -- this will be called again and the timer will be restarted.
+        self._node_added_timer.start(50)
+
+    def _on_node_removed(self, mobj: om.MObject, clientData: Any = None) -> None:
+        """
+        DG callback when a transform node is deleted.
+
+        Schedules a debounced tree refresh if the widget is visible.
+
+        :param mobj: Maya object that was removed.
+        :param clientData: Arbitrary client data passed by Maya.
+        :return: None
+        """
+        if not self.isVisible():
+            return
+
+        self._pending_scene_refresh = True
+        self._node_added_timer.start(100)
+
+    def _process_pending_scene_refresh(self) -> None:
+        """
+        Handle any pending scene refresh requested by the node-added callback.
+
+        Called by the debounce timer once there have been no new nodes added
+        for the timer interval.
+
+        :return: None
+        """
+        if not self._pending_scene_refresh:
+            return
+
+        # -- Clear the flag first to avoid accidental loops
+        self._pending_scene_refresh = False
+
+        # -- If the widget is no longer visible, skip the refresh
+        if not self.isVisible():
+            return
+
+        # -- Rebuild the tree from the scene
+        self.get_guide_from_scene()
+
+    def on_update_component_type_action_clicked(self) -> None:
+        """
+        Update the component type for the selected component using the DAG menu.
+
+        Ensures a single ShifterComponent is selected, selects the component
+        in the scene if needed, calls the compatibility helper, then rebuilds
+        the tree and attempts to reselect the updated component.
+
+        :return: None
+        """
+        items = self.selectedItems()
+        # -- If nothing is selected, do nothing.
+        if not items:
+            return
+
+        # -- Currently on considering single item selection
+        # -- Get the last selected item
+        data = items[-1].data(0, DATA_ROLE)
+
+        # -- Ensure it is a shifter component object
+        if not isinstance(data, ShifterComponent):
+            return
+
+        selected_uuid = data.uuid
+
+        # -- Ensure that we have something selected in order for something to be
+        # -- picked up by the command
+        if not self._scene_sync_enabled:
+            try:
+                node = shifter_utils.node_from_uuid(uuid=selected_uuid)
+            except Exception:
+                logger.warning(f"Could not resolve node from uuid: {selected_uuid}")
+                return
+
+            shifter_utils.select_items(items=[node])
+
+        # -- Update the component type
+        compatible_comp_dagmenu.update_component_type_and_update_guide_with_dagmenu()
+
+        # -- Rebuild the tree so UI/model and callbacks are correct
+        self.get_guide_from_scene()
+
+        self._block_scene_selection_sync = True
+        try:
+            self.clearSelection()
+            new_item = self._node_to_item.get(data.root_name)
+            print(new_item)
+            if not new_item:
+                return
+
+            self.setCurrentItem(new_item)
+            new_item.setSelected(True)
+        finally:
+            self._block_scene_selection_sync = False
+
+    def _enable_scene_callbacks(self) -> None:
+        """
+        Ensure scene callbacks are registered.
+
+        Only called when the widget becomes visible.
+
+        :return: None
+        """
+        if self._scene_callbacks_active:
+            return
+
+        # -- Selection changed
+        self._selection_cb_manager.selectionChangedCB("GuideOverview.Selection",
+                                                      self._on_scene_selection_changed)
+
+        # -- Node added, node removed
+        self._register_node_added_callback()
+        self._scene_callbacks_active = True
+
+    def _disable_scene_callbacks(self) -> None:
+        """
+        Remove scene callbacks.
+
+        Called when the widget is hidden or closed.
+
+        :return: None
+        """
+        if not self._scene_callbacks_active:
+            return
+
+        # -- Stop any pending node-added refresh
+        self._node_added_timer.stop()
+        self._pending_scene_refresh = False
+
+        # -- Remove selection callbacks
+        self._selection_cb_manager.removeAllManagedCB()
+
+        # -- Remove node-added callback
+        if self._node_added_cb_id is not None:
+            try:
+                om.MMessage.removeCallback(self._node_added_cb_id)
+            except Exception:
+                pass
+            self._node_added_cb_id = None
+
+        if self._node_removed_cb_id is not None:
+            try:
+                om.MMessage.removeCallback(self._node_removed_cb_id)
+            except Exception:
+                pass
+            self._node_removed_cb_id = None
+
+        self._scene_callbacks_active = False
+
+    def show_context_menu(self, point: QtCore.QPoint) -> None:
+        """
+        Show the context menu for the tree.
+
+        Builds the right-click menu with guide and component actions, then opens it
+        at the cursor position. The incoming point is in the viewport coordinate
+        system and is mapped to global screen space.
+
+        :param point: Position of the click in viewport coordinates.
+        :return: None
+        """
+        has_guide = bool(self._guide) and hasattr(self._guide[0], "node") and self._guide[0].node()
+        rig_list = shifter_utils.get_rig()
+        has_rig = bool(rig_list) and hasattr(rig_list[0], "node") and rig_list[0].node()
+
+        menu = QtWidgets.QMenu(self)
+
+        menu.addAction(self.build_action)
+        menu.addAction(self.unbuild_action)
+        menu.addSeparator()
+
+        # -- Visibility actions
+        visibility_actions: List[QtWidgets.QAction] = []
+
+        if has_guide:
+            visibility_actions.append(self.guide_visibility_action)
+
+        if has_rig:
+            visibility_actions.append(self.ctrl_visibility_action)
+            visibility_actions.append(self.joint_visibility_action)
+
+        for action in visibility_actions:
+            menu.addAction(action)
+
+        # -- Add separator only if at least one visibility action exists
+        if visibility_actions:
+            menu.addSeparator()
+
+        menu.addAction(self.mirror_component_action)
+        menu.addSeparator()
+        menu.addAction(self.delete_action)
+        menu.addSeparator()
+        menu.addAction(self.select_component_action)
+        menu.addSeparator()
+        menu.addAction(self.refresh_action)
+        menu.addSeparator()
+        menu.addAction(self.update_component_type_action)
+
+        menu.exec_(self.viewport().mapToGlobal(point))
+
+    def clear_items(self) -> None:
+        """
+        Clear all items and associated callbacks from the tree.
+
+        Removes all managed callbacks and resets the internal node-to-item maps.
+
+        :return: None
+        """
+        # -- Attribute callbacks on guide and components
+        self._attr_cb_manager.removeAllManagedCB()
+
+        # -- Clear tree items and maps
+        self.clear()
+        self._node_to_item.clear()
+        self._uuid_to_item.clear()
+        self._guide = None
+
+    def teardown(self) -> None:
+        """
+        Fully tear down the tree widget before the parent UI is closed.
+
+        This disables all scene callbacks and clears all items, mappings
+        and attribute callbacks.
+
+        :return: None
+        """
+        # -- Stop reacting to scene
+        self._disable_scene_callbacks()
+
+        # -- Clear tree model and attribute callbacks
+        self.clear_items()
+
+    def showEvent(self, event: QtCore.QEvent) -> None:
+        """
+        Qt show event handler.
+
+        When the tree becomes visible, enable scene callbacks.
+
+        :param event: Qt show event.
+        :return: None
+        """
+        super().showEvent(event)
+        self._enable_scene_callbacks()
+
+    def hideEvent(self, event: QtCore.QEvent) -> None:
+        """
+        Qt hide event handler.
+
+        When the tree is hidden, disable scene callbacks.
+
+        :param event: Qt hide event.
+        :return: None
+        """
+        self._disable_scene_callbacks()
+        super().hideEvent(event)

--- a/release/scripts/mgear/shifter/guide_explorer/guide_tree_widget_items.py
+++ b/release/scripts/mgear/shifter/guide_explorer/guide_tree_widget_items.py
@@ -1,0 +1,63 @@
+from mgear.vendor.Qt import QtCore, QtWidgets, QtGui
+from typing import Optional
+
+
+class GuideTreeWidgetItem(QtWidgets.QTreeWidgetItem):
+    """
+    Tree widget item representing the root mGear guide.
+
+    Displays the rig name with a character icon and bold font styling.
+    """
+    def __init__(self, parent: Optional[QtWidgets.QTreeWidgetItem], rig_name: str) -> None:
+        """
+        Initialize a guide tree item.
+
+        :param parent: Parent tree item or None for a top-level item.
+        :param rig_name: Name of the rig associated with the guide.
+        :return: None
+        """
+        super(GuideTreeWidgetItem, self).__init__(parent, [f"guide ({rig_name})"])
+
+        self.rig_name: str = rig_name
+
+        self.setIcon(0, QtGui.QIcon(":character.svg"))
+        self.setExpanded(True)
+
+        name_font = QtGui.QFont()
+        name_font.setBold(True)
+        self.setFont(0, name_font)
+        self.setToolTip(0, f"guide ({rig_name})")
+
+
+class ComponentTreeWidgetItem(QtWidgets.QTreeWidgetItem):
+    """
+    Tree widget item representing a single mGear component.
+
+    Shows the component name and type, with the type rendered in a
+    monospace font for readability.
+    """
+    def __init__(self,
+                 parent: Optional[QtWidgets.QTreeWidgetItem],
+                 component: str,
+                 comp_type: str) -> None:
+        """
+        Initialize a component tree item.
+
+        :param parent: Parent tree item, typically the guide root item.
+        :param component: Full component name, for example ``"arm_L0"``.
+        :param comp_type: Component type name, for example ``"arm_2jnt"``.
+        :return: None
+        """
+        super(ComponentTreeWidgetItem, self).__init__(parent, [component, comp_type])
+
+        self.component_name: str = component
+        self.component_type: str = comp_type
+
+        self.setIcon(0, QtGui.QIcon(":advancedSettings.png"))
+
+        self.setToolTip(0, component)
+
+        mono = QtGui.QFont("Consolas")
+        mono.setStyleHint(QtGui.QFont.Monospace)
+        self.setFont(1, mono)
+        self.setToolTip(1, comp_type)

--- a/release/scripts/mgear/shifter/guide_explorer/models.py
+++ b/release/scripts/mgear/shifter/guide_explorer/models.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ShifterComponent:
+    """
+    Reference to a Shifter component in the scene.
+
+    :param full_name: mGear guide key, for example "arm_L0".
+    :param comp_type: mGear component type, for example "arm_2jnt".
+    :param root_name: Root transform of the component.
+    :param side: Component side string, for example "L" or "R".
+    :param index: Component index on the given side.
+    :param uuid: UUID of the component root transform.
+    """
+    full_name: str
+    comp_type: str
+    root_name: str
+    side: str
+    index: int
+    uuid: str

--- a/release/scripts/mgear/shifter/guide_explorer/utils.py
+++ b/release/scripts/mgear/shifter/guide_explorer/utils.py
@@ -1,0 +1,47 @@
+from typing import List, Sequence, Union
+import mgear.pymaya as pm
+
+
+class TempSelection:
+    """
+    Context manager that temporarily replaces the Maya selection.
+
+    Restores the previous selection when leaving the context.
+    """
+    def __init__(self, nodes: Union[pm.PyNode, Sequence[pm.PyNode]]) -> None:
+        """
+        :param nodes: Node or sequence of nodes to select while in context.
+        """
+        self._nodes = nodes if isinstance(nodes, (list, tuple)) else [nodes]
+        self._prev: List[pm.PyNode] = []
+
+    def __enter__(self) -> "TempSelection":
+        """
+        Store current selection and select the temporary nodes.
+
+        :return: This context manager instance.
+        """
+        try:
+            # -- Store current selection (PyNodes)
+            self._prev = pm.ls(selection=True)
+        except Exception:
+            self._prev = []
+        try:
+            pm.select(self._nodes, replace=True)
+        except Exception:
+            pass
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        """
+        Restore the previous selection on context exit.
+
+        :return: None
+        """
+        try:
+            if self._prev:
+                pm.select(self._prev, replace=True)
+            else:
+                pm.select(clear=True)
+        except Exception:
+            pass

--- a/release/scripts/mgear/shifter/guide_manager_gui.py
+++ b/release/scripts/mgear/shifter/guide_manager_gui.py
@@ -1,9 +1,13 @@
-from mgear.shifter import guide_manager_component, guide_template_explorer
 from mgear.vendor.Qt import QtCore, QtWidgets
+
+from mgear.shifter import guide_manager_component, guide_template_explorer
+from mgear.shifter.guide_explorer import guide_explorer_widget
+
 from maya.app.general.mayaMixin import MayaQWidgetDockableMixin
 from mgear.core import pyqt
 
-
+import importlib
+importlib.reload(guide_explorer_widget)
 # guides manager UI
 
 class GuideManager(MayaQWidgetDockableMixin, QtWidgets.QDialog):
@@ -14,6 +18,7 @@ class GuideManager(MayaQWidgetDockableMixin, QtWidgets.QDialog):
 
         self.gmc = guide_manager_component.GuideManagerComponent()
         self.gexp = guide_template_explorer.GuideTemplateExplorer()
+        self.guide_explorer = guide_explorer_widget.GuideExplorerWidget(self)
         self.installEventFilter(self)
         self.create_window()
         self.create_layout()
@@ -36,11 +41,24 @@ class GuideManager(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         self.tabs = QtWidgets.QTabWidget()
         self.tabs.setObjectName("manager_tab")
         self.tabs.insertTab(0, self.gmc, "Components")
-        self.tabs.insertTab(1, self.gexp, "Templates")
+        self.tabs.insertTab(1, self.guide_explorer, "Guide Explorer")
+        self.tabs.insertTab(2, self.gexp, "Templates")
 
         self.gm_layout.addWidget(self.tabs)
 
         self.setLayout(self.gm_layout)
+
+    def dockCloseEventTriggered(self):
+
+        try:
+            self.guide_explorer.teardown()
+        except Exception:
+            pass
+        # -- Let Maya finish destroying the dock
+        try:
+            super(GuideManager, self).dockCloseEventTriggered()
+        except Exception:
+            pass
 
 
 def show_guide_manager(*args):

--- a/release/scripts/mgear/shifter/utils.py
+++ b/release/scripts/mgear/shifter/utils.py
@@ -1,4 +1,5 @@
 from mgear import pymaya as pm
+from typing import Any, Iterable, List, Optional
 
 
 def get_deformer_joint_grp(rigTopNode):
@@ -62,8 +63,216 @@ def get_root_joint(rigTopNode):
     return root_jnt
 
 
-def get_guide():
+def get_guide() -> List[pm.PyNode]:
     """
     Get the guide top node in the scene.
+
+    :return: List of guide nodes that have the attribute 'ismodel'.
     """
     return pm.ls("*.ismodel") or []
+
+
+def get_rig() -> List[pm.PyNode]:
+    """
+    Get the rig top node in the scene.
+
+    :return: List of rig nodes that have the attribute 'is_rig'.
+    """
+    return pm.ls("*.is_rig") or []
+
+
+def get_rig_name(guide: str) -> [str]:
+    """
+    Get the rig name from the guide.
+    """
+    return pm.getAttr(f"{guide}.rig_name")
+
+
+def get_components(guide_name: str) -> List[pm.PyNode]:
+    """
+    Return all valid component transforms under the given guide.
+
+    Traverses all descendant transforms of the guide and filters out
+    nodes that do not have a 'comp_type' attribute.
+
+    :param guide_name: Name of the guide root.
+    :return: List of component transform nodes that have 'comp_type'.
+    :rtype: list
+    """
+    components = pm.listRelatives(guide_name,
+                                  children=True,
+                                  allDescendents=True,
+                                  type="transform",
+                                  fullPath=True)
+
+    valid_components: List[pm.PyNode] = []
+    # -- Filter out components
+    for cmp in components:
+        if not cmp.hasAttr("comp_type"):
+            continue
+        valid_components.append(cmp)
+
+    return valid_components
+
+
+def obj_exists(node: str) -> bool:
+    """
+    Check whether a DAG or DG node exists in the Maya scene.
+
+    :param node: Name of the node to check.
+    :return: True if the node exists, otherwise False.
+    """
+    return bool(node) and pm.objExists(node)
+
+
+def select_items(items: Iterable[str], replace: bool = True) -> None:
+    """
+    Select the given items in the Maya scene.
+
+    :param items: A single node name or a list/iterable of node names.
+    :param replace: If True, replace the current selection. If False, add to it.
+    :return: None
+    """
+    # -- Normalize to list and filter only items that exist
+    normalized: List[str] = [i for i in to_list(items) if obj_exists(i)]
+
+    if not normalized:
+        return
+
+    if replace:
+        pm.select(clear=True)
+
+    pm.select(normalized, add=not replace)
+
+
+def to_list(x) -> List[str]:
+    """
+    Normalize an input into a flat list of strings.
+
+    :param x: A string, iterable of strings, or any value.
+    :return: A list of strings.
+    """
+    if x is None:
+        return []
+    if isinstance(x, str):
+        return [x]
+    if isinstance(x, Iterable):
+        return list(x)
+    return [x]
+
+
+def delete_nodes(nodes: List) -> None:
+    """
+    Delete the given Maya nodes safely.
+
+    :param nodes: List of node names or PyNodes to delete.
+    :type nodes: List
+    """
+    for node in nodes:
+        try:
+            pm.delete(node)
+        except:
+            print(f"Could not delete node: {node}")
+
+
+def select_by_uuid(uuid: str) -> Optional[pm.PyNode]:
+    """
+    Select a Maya node by its UUID.
+
+    :param uuid: The UUID of the node to select.
+    :return: The selected PyNode, or None if no node was found.
+    """
+    node = node_from_uuid(uuid=uuid)
+
+    # -- Exit early
+    if node is None:
+        return
+
+    pm.select(node, replace=True)
+
+    return node
+
+
+def node_from_uuid(uuid: str) -> Optional[pm.PyNode]:
+    """
+    Resolve a Maya node from its UUID.
+
+    :param str uuid: The UUID string of the node to look up.
+    :return: The resolved PyNode if it exists, otherwise 'None'.
+    :rtype: Optional[pm.PyNode]
+    """
+    try:
+        nodes = pm.ls(uuid, uuid=True)
+    except Exception:
+        return None
+    return nodes[0] if nodes else None
+
+
+def uuid_from_node(node: Any) -> Optional[str]:
+    """
+    Return the UUID string for a given Maya node.
+
+    :param Any node: A node reference, name, or PyNode-like object.
+    :return: The UUID string if resolved, otherwise 'None'.
+    :rtype: Optional[str]
+    """
+
+    pynode = node_from_name(node)
+
+    if pynode is None:
+        return None
+
+    try:
+        uuids = pm.ls(pynode, uuid=True)
+    except Exception:
+        return None
+
+    return uuids[0] if uuids else None
+
+
+def node_from_name(name: str) -> Optional[pm.PyNode]:
+    """
+    Resolve a Maya node from its name.
+
+    :param str name: The node name to convert into a PyNode.
+    :return: The resolved PyNode if it exists, otherwise 'None'.
+    :rtype: Optional[pm.PyNode]
+    """
+    try:
+        return pm.PyNode(name)
+    except Exception:
+        return None
+
+
+def get_selection() -> List[pm.PyNode]:
+    """
+    Return the current Maya selection as a list of PyNodes.
+
+    :return: List of selected nodes.
+    """
+    return pm.ls(selection=True)
+
+
+def find_component_root(node):
+    """
+    Walks up the DAG hierarchy from the given node until a node with
+    the `comp_type` attribute is found. This identifies the root of an
+    mGear component or guide.
+
+    :param node: Node to start searching from. Can be a name or PyNode.
+    :return: The component root node, or None if not found.
+    """
+    if isinstance(node, str):
+        node = pm.PyNode(node)
+
+    current = node
+
+    while current:
+        if current.hasAttr("comp_type"):
+            return current
+        parent = current.getParent()
+        if not parent or parent == current:
+            break
+        current = parent
+
+    return None


### PR DESCRIPTION
## Description of Changes

This PR introduces the Guide Explorer, a new UI tool for inspecting and managing Shifter guides.
It provides a structured tree view of all guide components, a details panel for viewing and editing component settings, and supporting utilities for querying and interacting with guide data.

New modules under mgear/shifter/guide_explorer/ include the main widget, tree widget, tree items, data models, and helper utilities.
Existing Shifter modules were updated to integrate the Guide Explorer into the workflow.

Note: This PR depends on the changes in #584 and should be merged after that one.

## Testing Done

- Loaded various guides to verify the tree populates correctly.
- Confirmed selection sync between UI and Maya scene (component selection, root selection, empty states).
- Tested settings panel updates when switching between components.
- Reopened the tool across scene reloads to confirm stability and no script errors.

## Related Issue(s)

New feature. #591 



