### PR TITLE
Refresh metadata on .SGT export

### DIFF
--- a/release/scripts/mgear/core/utils.py
+++ b/release/scripts/mgear/core/utils.py
@@ -1,10 +1,12 @@
-"""Utilitie functions"""
+"""Utility functions"""
 
 
 import os
 import sys
 import timeit
 from functools import wraps
+import datetime
+import getpass
 
 from maya import cmds
 import mgear.pymaya as pm
@@ -441,3 +443,17 @@ def get_maya_path():
     maya_path = os.environ['MAYA_LOCATION']
     maya_path = os.path.normpath(os.path.join(maya_path,"bin"))
     return maya_path
+
+
+def get_user_metadata():
+    """
+    :return: User metadata including username, date, Maya version, and mGear version.
+    :rtype: dict[str, str]
+    """
+    data = {
+        "user": getpass.getuser(),
+        "date": str(datetime.datetime.now()),
+        "maya_version": str(mel.eval("getApplicationVersionAsFloat")),
+        "gear_version": mgear.getVersion(),
+    }
+    return data

--- a/release/scripts/mgear/shifter/guide.py
+++ b/release/scripts/mgear/shifter/guide.py
@@ -1,6 +1,5 @@
 # Built-in
 import datetime
-import getpass
 import json
 import os
 import sys
@@ -628,17 +627,17 @@ class Rig(Main):
         # --------------------------------------------------
         # Comments
         self.pComments = self.addParam("comments", "string", "")
-        self.pUser = self.addParam("user", "string", getpass.getuser())
-        self.pDate = self.addParam(
-            "date", "string", str(datetime.datetime.now())
-        )
+
+        user_metadata = utils.get_user_metadata()
+        self.pUser = self.addParam("user", "string", user_metadata["user"])
+        self.pDate = self.addParam("date", "string", user_metadata["date"])
         self.pMayaVersion = self.addParam(
             "maya_version",
             "string",
-            str(pm.mel.eval("getApplicationVersionAsFloat")),
+            user_metadata["maya_version"],
         )
         self.pGearVersion = self.addParam(
-            "gear_version", "string", mgear.getVersion()
+            "gear_version", "string", user_metadata["gear_version"]
         )
 
         # --------------------------------------------------
@@ -1073,22 +1072,10 @@ class Rig(Main):
 
         return self.guide_template_dict
 
-    def refresh_metadata(self):
-        attr = self.model.attr("user")
-        newvalue = getpass.getuser()
-        attr.set(newvalue)
-
-        attr = self.model.attr("date")
-        newvalue = str(datetime.datetime.now())
-        attr.set(newvalue)
-
-        attr = self.model.attr("maya_version")
-        newvalue = str(mel.eval("getApplicationVersionAsFloat"))
-        attr.set(newvalue)
-
-        attr = self.model.attr("gear_version")
-        newvalue = mgear.getVersion()
-        attr.set(newvalue)
+    def refresh_user_metadata(self):
+        for k, v in utils.get_user_metadata().items():
+            attr = self.model.attr(k)
+            attr.set(v)
 
     def addOptionsValues(self):
         """Gather or change some options values according to some others.
@@ -3825,7 +3812,6 @@ class GuideSettings(MayaQWidgetDockableMixin, csw.CustomStepMixin, GuideMainSett
             pm.displayWarning(
                 "Nothing selected or selection is not joint or Transform type"
             )
-
 
 
 # Backwards compatibility aliases

--- a/release/scripts/mgear/shifter/guide.py
+++ b/release/scripts/mgear/shifter/guide.py
@@ -1073,6 +1073,23 @@ class Rig(Main):
 
         return self.guide_template_dict
 
+    def refresh_metadata(self):
+        attr = self.model.attr("user")
+        newvalue = getpass.getuser()
+        attr.set(newvalue)
+
+        attr = self.model.attr("date")
+        newvalue = str(datetime.datetime.now())
+        attr.set(newvalue)
+
+        attr = self.model.attr("maya_version")
+        newvalue = str(mel.eval("getApplicationVersionAsFloat"))
+        attr.set(newvalue)
+
+        attr = self.model.attr("gear_version")
+        newvalue = mgear.getVersion()
+        attr.set(newvalue)
+
     def addOptionsValues(self):
         """Gather or change some options values according to some others.
 

--- a/release/scripts/mgear/shifter/io.py
+++ b/release/scripts/mgear/shifter/io.py
@@ -145,14 +145,19 @@ def _get_file(write=False):
 
 
 def export_guide_template(filePath=None, meta=None, conf=None, *args):
-    """Export the guide templata to a file
+    """Export the guide template to a file.
 
     Args:
-        filePath (str, optional): Path to save the file
-        meta (dict, optional): Arbitraty metadata dictionary. This can
-            be use to store any custom information in a dictionary format.
+        filePath (str, optional): Path to save the file.
+        meta (dict, optional): Arbitrary metadata dictionary. This can
+            be used to store any custom information in a dictionary format.
     """
     if not conf:
+        selection = pm.selected()
+        if selection:
+            rig = shifter.Rig()
+            rig.guide.setFromHierarchy(selection[0])
+            rig.guide.refresh_metadata()
         conf = get_template_from_selection(meta)
     if conf:
         data_string = json.dumps(conf, indent=4, sort_keys=True)

--- a/release/scripts/mgear/shifter/io.py
+++ b/release/scripts/mgear/shifter/io.py
@@ -157,7 +157,7 @@ def export_guide_template(filePath=None, meta=None, conf=None, *args):
         if selection:
             rig = shifter.Rig()
             rig.guide.setFromHierarchy(selection[0])
-            rig.guide.refresh_metadata()
+            rig.guide.refresh_user_metadata()
         conf = get_template_from_selection(meta)
     if conf:
         data_string = json.dumps(conf, indent=4, sort_keys=True)


### PR DESCRIPTION
## Description of Changes
1. Add a method to refresh a guide's metadata (e.g. user, datetime, versions).
1. Exporting an SGT will now implicitly call this refresh method.
    1.  Only applies to selection-based export. It is assumed the data should not change if caller explicitly passes conf data.

Currently, if someone were to start from a guide sample and make changes, the exported SGT would still say it is "exported by Miquel in 2020"! 

## Testing Done

mGear 5.2.1
Maya 2026
Windows 11

Able to import sample guides, then export SGT with new metadata.
Able to import the new SGT properly.

## Related Issue(s)

N/A


