### PR TITLE
Fix dagmenu right-click crash on Maya 2025

### DIFF
--- a/release/scripts/mgear/core/dagmenu.py
+++ b/release/scripts/mgear/core/dagmenu.py
@@ -185,6 +185,12 @@ def _get_switch_node_attrs(node, end_string):
                 "{}.{}".format(node, attr), query=True, usedAsProxy=True
             ):
                 continue
+            # Skip string attributes — switch/blend attrs are enum or numeric
+            attr_type = cmds.attributeQuery(
+                attr, node=node, attributeType=True
+            )
+            if attr_type in ("string", "typed"):
+                continue
             attrs.append(attr)
     return attrs
 
@@ -1136,9 +1142,13 @@ def mgear_dagmenu_fill(parent_menu, current_control):
                 image="dynamicConstraint.svg",
             )
             cmds.radioMenuItemCollection(parent=_p_switch_menu)
-            k_values = cmds.addAttr(
+            enum_name = cmds.addAttr(
                 "{}.{}".format(uih, attr), query=True, enumName=True
-            ).split(":")
+            )
+            if not enum_name:
+                cmds.deleteUI(_p_switch_menu)
+                continue
+            k_values = enum_name.split(":")
             current_state = cmds.getAttr("{}.{}".format(uih, attr))
 
             combo_box = QtWidgets.QComboBox()

--- a/release/scripts/mgear/core/pickWalk.py
+++ b/release/scripts/mgear/core/pickWalk.py
@@ -47,6 +47,7 @@ def get_all_tag_children(node):
             for ct in child_tags:
                 if ct in seen_tags:
                     continue
+                seen_tags.add(ct)
                 ctl = cmds.listConnections(
                     "{}.controllerObject".format(ct)
                 )

--- a/release/scripts/mgear/core/pickWalk.py
+++ b/release/scripts/mgear/core/pickWalk.py
@@ -14,6 +14,10 @@ from mgear.core import string
 def get_all_tag_children(node):
     """Gets all child tag controls from the given tag node
 
+    Traverses controller tag hierarchy using listConnections instead of
+    cmds.controller, which can segfault in Maya 2025 on certain
+    controller tag nodes.
+
     Args:
         node (str): Name of controller object with tag
 
@@ -21,22 +25,35 @@ def get_all_tag_children(node):
         list: List of child controls (Maya transform nodes)
     """
 
-    # store child nodes
     children = []
 
-    # gets first child control
-    child = cmds.controller(node, query=True, children=True)
+    tags = cmds.ls(cmds.listConnections(node, type="controller"))
+    if not tags:
+        return children
 
-    # loop on child controller nodes to get all children
-    while child is not None:
-        children.extend(child)
-        tags = []
-        for c in child:
-            tag = cmds.ls(cmds.listConnections(c, type="controller"))
-            tags.extend(tag)
-            if cmds.listConnections("{}.parent".format(tag[0])) == node:
-                return children
-        child = cmds.controller(tags, query=True, children=True)
+    current_tags = tags
+    seen_tags = set()
+    while current_tags:
+        next_tags = []
+        for tag in current_tags:
+            if tag in seen_tags:
+                continue
+            seen_tags.add(tag)
+            child_tags = cmds.listConnections(
+                "{}.children".format(tag), type="controller"
+            )
+            if not child_tags:
+                continue
+            for ct in child_tags:
+                if ct in seen_tags:
+                    continue
+                ctl = cmds.listConnections(
+                    "{}.controllerObject".format(ct)
+                )
+                if ctl:
+                    children.extend(ctl)
+                next_tags.append(ct)
+        current_tags = next_tags
 
     return children
 


### PR DESCRIPTION
## Summary

- Fix `cmds.controller` C++ segfault in `get_all_tag_children` that crashes Maya 2025 on right-click (fixes #623)
- Fix false positive attribute matching in `_get_switch_node_attrs` that matches string attributes as space-switch enums (fixes #624)

## Changes

### pickWalk.py — `get_all_tag_children`
Replace `cmds.controller(query=True, children=True)` with direct `cmds.listConnections` traversal of controller tag `.children` and `.controllerObject` attributes. `cmds.controller` has a C++ bug in Maya 2025 that segfaults on certain controller tag nodes. Also adds a `seen_tags` set to prevent infinite loops from circular tag references.

### dagmenu.py — `_get_switch_node_attrs`
Add attribute type check to skip `string`/`typed` attributes, since space-switch attributes are always enum or numeric. String attributes like `guide_loc_ref` ending in `"ref"` were matching as false positives.

### dagmenu.py — space-switch menu builder
Add null guard on `cmds.addAttr(query=True, enumName=True)` result before calling `.split(":")`. Non-enum attributes return `None`, causing an `AttributeError`.

## Testing

Tested with Maya 2025 on a production rig with full controller tag hierarchy (body → spine → neck → arms → hands → fingers). Right-click menu works correctly on all control types (body, spine, arm, single and multi-selection).